### PR TITLE
Remove dotted border with outline-style: none

### DIFF
--- a/less/buttons.less
+++ b/less/buttons.less
@@ -53,6 +53,7 @@
 .btn:focus {
   /* Blue border on button focus. */
   border-color: #4D90FE;
+  outline-style: none;
 }
 .btn.active {
   background: #e8e8e8;
@@ -393,4 +394,3 @@
   border-color: lighten(@btnInverseBackground, 10%);
   background-color: lighten(@btnInverseBackground, 15%);
 }
-


### PR DESCRIPTION
Added outline-style: none; to buttons active and focus properties to remove the dotted border that appears in some browsers (FF for example)
