### PR TITLE
Removed bottom border on :active state for Google tabs

### DIFF
--- a/less/navs.less
+++ b/less/navs.less
@@ -98,7 +98,6 @@
     }
 
     // Active state, and it's :hover to override normal :hover
-    > a:active,
     &.active > a {
       &,
       &:hover,


### PR DESCRIPTION
Just noticed a small bug while testing out my changes.
:active state should not have a bottom border. (Sorry for bothering you with all these changes).
