### PR TITLE
Fix a clash between focused and hovered buttons

### DIFF
--- a/less/button-groups.less
+++ b/less/button-groups.less
@@ -12,6 +12,13 @@
   }
 }
 
+// Border of a focused button shouldn't get hidden when the next button in the group is hovered
+.btn-group,
+.btn-group-vertical {
+  > .btn:focus {
+    z-index: 3;
+  }
+}
 
 // Sizing
 //


### PR DESCRIPTION
Border of a focused button shouldn't get hidden when the next button in the group is hovered.
![gofigure](https://cloud.githubusercontent.com/assets/94334/4176640/2e7e4674-360e-11e4-9b74-10a4c9b614d8.png)
