### PR TITLE
Proper fix #179

### DIFF
--- a/less/buttons.less
+++ b/less/buttons.less
@@ -19,7 +19,6 @@
     &:focus,
     &.focus {
       outline: none;
-      box-shadow: none;
     }
   }
 

--- a/less/mixins/buttons.less
+++ b/less/mixins/buttons.less
@@ -39,8 +39,10 @@
   }
   &:focus,
   &.focus {
-    border: 1px solid @border-color;
-    .box-shadow(inset 0 0 0 1px #fff);
+    &:not(:active):not(.active) {
+      border: 1px solid @border-color;
+      .box-shadow(inset 0 0 0 1px #fff);
+    }
   }
   &.disabled,
   &[disabled],


### PR DESCRIPTION
You fix make the inner shadow none:
<img width="204" alt="2017-03-28 22_36_54-css todc bootstrap" src="https://cloud.githubusercontent.com/assets/15178410/24411001/3468654a-1407-11e7-943d-9befdbb50790.png">

So do a proper fix:
<img width="202" alt="2017-03-28 22_36_48-css todc bootstrap" src="https://cloud.githubusercontent.com/assets/15178410/24410985/1d1885f0-1407-11e7-8799-13e94e7342e7.png">


**Warning**:
I edited file in web browser, I am not run `build`, so you should `build` it later.